### PR TITLE
Update repack-and-release.yml to use upload-artifact v4

### DIFF
--- a/.github/workflows/repack-and-release.yml
+++ b/.github/workflows/repack-and-release.yml
@@ -56,7 +56,7 @@ jobs:
 
     - name: Upload artifacts
       if: ${{ success() }}
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: FunTuna
         path: |


### PR DESCRIPTION
**Changes**:  
- Replaced `actions/upload-artifact@v2` → `@v4` in `.github/workflows/repack-and-release.yml`
- Maintained identical artifact path configuration